### PR TITLE
Fix deprecated env api

### DIFF
--- a/gym_maze/envs/maze_env.py
+++ b/gym_maze/envs/maze_env.py
@@ -50,23 +50,23 @@ class MazeEnv(gym.Env):
         self.steps_beyond_done = None
 
         # Simulation related variables.
-        self._seed()
+        self.seed()
         self.reset()
 
         # Just need to initialize the relevant attributes
-        self._configure()
+        self.configure()
 
     def __del__(self):
         self.maze_view.quit_game()
 
-    def _configure(self, display=None):
+    def configure(self, display=None):
         self.display = display
 
-    def _seed(self, seed=None):
+    def seed(self, seed=None):
         self.np_random, seed = seeding.np_random(seed)
         return [seed]
 
-    def _step(self, action):
+    def step(self, action):
         if isinstance(action, int):
             self.maze_view.move_robot(self.ACTION[action])
         else:
@@ -85,7 +85,7 @@ class MazeEnv(gym.Env):
 
         return self.state, reward, done, info
 
-    def _reset(self):
+    def reset(self):
         self.maze_view.reset_robot()
         self.state = np.zeros(2)
         self.steps_beyond_done = None
@@ -95,7 +95,7 @@ class MazeEnv(gym.Env):
     def is_game_over(self):
         return self.maze_view.game_over
 
-    def _render(self, mode="human", close=False):
+    def render(self, mode="human", close=False):
         if close:
             self.maze_view.quit_game()
 


### PR DESCRIPTION
The OpenAI gym changed their environment API a while ago. Removing the private-method naming style fixes the environment for up to Gym 0.10.11.