### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The objective is to find the shortest path from the start to the goal.
 <kbd>![Simple 2D maze environment](http://i.giphy.com/Ar3aKxkAAh3y0.gif)</kbd>
 
 ### Action space
-The agent may only choose to go up, down, left, or right ("N", "S", "W", "E"). If the way is blocked, it will remain at the same the location. 
+The agent may only choose to go up, down, right, or left ("N", "S", "E", "W"). If the way is blocked, it will remain at the same the location. 
 
 ### Observation space
 The observation space is the (x, y) coordinate of the agent. The top left cell is (0, 0).


### PR DESCRIPTION
Readme documentation gave wrong directions for action space.
https://github.com/MattChanTK/gym-maze/blob/master/gym_maze/envs/maze_env.py#L14 here we can see that it is actually ["N", "S", "E", "W"]
So by reading the documentation you would think that action 2 would be left (W) and action 3 would be right (E), but in the environment they are opposite.