### PR TITLE
Added a new environment for custom maze size specified by the user

### DIFF
--- a/gym_maze/__init__.py
+++ b/gym_maze/__init__.py
@@ -61,6 +61,13 @@ register(
 )
 
 register(
+    id='maze-random-custom-v0',
+    entry_point='gym_maze.envs:MazeEnvRandomCustom',
+    max_episode_steps=1000000,
+    nondeterministic=True,
+)
+
+register(
     id='maze-random-10x10-plus-v0',
     entry_point='gym_maze.envs:MazeEnvRandom10x10Plus',
     max_episode_steps=1000000,

--- a/gym_maze/envs/maze_env.py
+++ b/gym_maze/envs/maze_env.py
@@ -154,6 +154,11 @@ class MazeEnvRandom100x100(MazeEnv):
         super(MazeEnvRandom100x100, self).__init__(maze_size=(100, 100), enable_render=enable_render)
 
 
+class MazeEnvRandomCustom(MazeEnv):
+    def __init__(self, maze_size, enable_render=True):
+        super(MazeEnvRandomCustom, self).__init__(maze_size=maze_size, enable_render=enable_render)
+
+
 class MazeEnvRandom10x10Plus(MazeEnv):
 
     def __init__(self, enable_render=True):


### PR DESCRIPTION
I needed some larger maze environments and added support for a custom maze size env. This way if there is need for a custom maze size it can specified when creating the environment.

Some examples how to use it.
```python
import gym 
import gym_maze

env = gym.make("maze-random-custom-v0", maze_size=(150, 150))
```

```python
import gym 
from gym_maze import envs

env = envs.MazeEnvRandomCustom(maze_size=(150,150), enable_render=False)
```