### PR TITLE
Fix Gym and NumPy versions and environment names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,23 +20,23 @@ The maze is reset when the agent reaches the goal.
 ## Maze Versions
 
 ### Pre-generated mazes
-* 3 cells x 3 cells: _MazeEnvSample3x3_
-* 5 cells x 5 cells: _MazeEnvSample5x5_
-* 10 cells x 10 cells: _MazeEnvSample10x10_
-* 100 cells x 100 cells: _MazeEnvSample100x100_
+* 3 cells x 3 cells: _maze-sample-3x3-v0_
+* 5 cells x 5 cells: _maze-sample-5x5-v0_
+* 10 cells x 10 cells: _maze-sample-10x10-v0_
+* 100 cells x 100 cells: _maze-sample-100x100-v0_
 
 ### Randomly generated mazes (same maze every epoch)
-* 3 cells x 3 cells: _MazeEnvRandom3x3_
-* 5 cells x 5 cells: _MazeEnvRandom5x5_
-* 10 cells x 10 cells: _MazeEnvRandom10x10_
-* 100 cells x 100 cells: _MazeEnvRandom100x100_
+* 3 cells x 3 cells: _maze-random-3x3-v0_
+* 5 cells x 5 cells: _maze-random-5x5-v0_
+* 10 cells x 10 cells: _maze-random-10x10-v0_
+* 100 cells x 100 cells: _maze-random-100x100-v0_
 
 ### Randomly generated mazes with portals and loops
 With loops, it means that there will be more than one possible path.
 The agent can also teleport from a portal to another portal of the same colour. 
-* 10 cells x 10 cells: _MazeEnvRandom10x10Plus_
-* 20 cells x 20 cells: _MazeEnvRandom20x20Plus_
-* 30 cells x 30 cells: _MazeEnvRandom30x30Plus_
+* 10 cells x 10 cells: _maze-random-10x10-plus-v0_
+* 20 cells x 20 cells: _maze-random-20x20-plus-v0_
+* 30 cells x 30 cells: _maze-random-30x30-plus-v0_
 
 ## Installation
 It should work on both Python 2.7+ and 3.4+. It requires pygame and numpy. 

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(name="gym_maze",
       package_data = {
           "gym_maze.envs": ["maze_samples/*.npy"]
       },
-      install_requires = ["gym", "pygame", "numpy"]
+      install_requires = ["gym==0.23.1", "pygame", "numpy==1.26.1"]
 )


### PR DESCRIPTION
I noticed the package is not compatible with recent NumPy and Gym versions, so I set them to `numpy==1.26.1` and `gym==0.23.1` in `setup.py`. This seemed to fix the compatibility issues. In addition, I fixed the environment names in `README.md`.

ISSUES:
```
>>> env = gym.make("maze-sample-3x3")
>>> obs = env.reset()
>>> act = env.action_space.sample()
>>> obs = env.step(act)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/USERNAME/miniconda3/envs/gymtest/lib/python3.10/site-packages/gym-0.26.2-py3.10.egg/gym/wrappers/time_limit.py", line 50, in step
    observation, reward, terminated, truncated, info = self.env.step(action)
  File "/Users/USERNAME/miniconda3/envs/gymtest/lib/python3.10/site-packages/gym-0.26.2-py3.10.egg/gym/wrappers/order_enforcing.py", line 37, in step
    return self.env.step(action)
  File "/Users/USERNAME/miniconda3/envs/gymtest/lib/python3.10/site-packages/gym-0.26.2-py3.10.egg/gym/wrappers/env_checker.py", line 37, in step
    return env_step_passive_checker(self.env, action)
  File "/Users/USERNAME/miniconda3/envs/gymtest/lib/python3.10/site-packages/gym-0.26.2-py3.10.egg/gym/utils/passive_env_checker.py", line 225, in env_step_passive_checker
    if not isinstance(done, (bool, np.bool8)):
  File "/Users/USERNAME/miniconda3/envs/gymtest/lib/python3.10/site-packages/numpy-2.1.2-py3.10-macosx-10.15-x86_64.egg/numpy/__init__.py", line 414, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'bool8'. Did you mean: 'bool'?
```

```
>>> env = gym.make("maze-sample-3x3")
>>> obs = env.reset()
>>> act = env.action_space.sample()
>>> obs = env.step(act)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/USERNAME/miniconda3/envs/gymtest/lib/python3.10/site-packages/gym-0.26.2-py3.10.egg/gym/wrappers/time_limit.py", line 50, in step
    observation, reward, terminated, truncated, info = self.env.step(action)
ValueError: not enough values to unpack (expected 5, got 4)
```